### PR TITLE
Constraining Waf to only look for the supported versions of Python

### DIFF
--- a/bin/waf.bat
+++ b/bin/waf.bat
@@ -26,7 +26,7 @@ Setlocal EnableDelayedExpansion
 set PYTHON_DIR_OK=FALSE
 set REGPATH=
 
-for %%i in (3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 2.5 2.4 2.3) do (
+for %%i in (2.7 2.6) do (
 for %%j in (HKCU HKLM) do (
 for %%k in (SOFTWARE\Wow6432Node SOFTWARE) do (
 for %%l in (Python\PythonCore IronPython) do (


### PR DESCRIPTION
This is a possible approach to addressing issue #1 by simply constraining the set of searched for python versions to just that of the approved versions.
