### PR TITLE
Enable modern compiler versions to use --cpp11.

### DIFF
--- a/etc/default.opts
+++ b/etc/default.opts
@@ -119,6 +119,7 @@
 ++  *                     cpp11  CPP11_FLAGS   =  --this-compiler-does-not-have-cpp11-support-configured
 !!  unix-*-*-*-gcc-4.4.3  cpp11  CPP11_FLAGS   =  -std=c++0x
 !!  unix-*-*-*-gcc-4.7.0  cpp11  CPP11_FLAGS   =  -std=c++11
+!!  unix-*-*-*-gcc-clang  cpp11  CPP11_FLAGS   =  -std=c++11
 ++  *                     cpp11  BDE_CXXFLAGS  =  $(CPP11_FLAGS)
 
 #==============================================================================


### PR DESCRIPTION
The `waf configure --cpp11` flag will only enable C++11 mode when using whitelisted compilers. This updates the list of allowed compilers to include the current production release of `g++` 4.7, 4.8, 4.9 and `clang++`, since these are most commonly found on any updated system.
