### PR TITLE
Arm support

### DIFF
--- a/etc/default.opts
+++ b/etc/default.opts
@@ -473,6 +473,10 @@ unix-*-*-*-gcc-4.2   _  GCCEXTRAWFLAGS  =   \
 !!  *-*-*-*-clang              64       CC64FLAGS                 =  -m64
 !!  *-*-x86_64-*-clang         _        CC64FLAGS                 =  -m32 -march=pentium2 -mtune=opteron
 !!  *-*-x86_64-*-clang         64       CC64FLAGS                 =  -m64 -mtune=opteron
+++  unix-SunOS-*-*-gcc         _        CC64FLAGS                 =  -m32
+!!  unix-SunOS-*-*-gcc         64       CC64FLAGS                 =  -m64
+++  unix-AIX-*-*-gcc           _        CC64FLAGS                 =  -maix32
+!!  unix-AIX-*-*-gcc           64       CC64FLAGS                 =  -maix64
 
 # DRQS 10505346 -- switch to -xtarget=ultra3 for Sun, -qarch=pwr4 -qtune=pwr5 for AIX
 # old flags

--- a/etc/default.opts
+++ b/etc/default.opts
@@ -465,8 +465,8 @@ unix-*-*-*-gcc-4.2   _  GCCEXTRAWFLAGS  =   \
 ++  *-*-*-*-gcc-4.3            _        GCCEXTRAWFLAGS            =  $(GCCEXTRAWFLAGS_CAST_QUAL)
 
 ++  *                          _        CC64FLAGS                 =
-++  *-*-*-*-gcc                _        CC64FLAGS                 =  -m32
-!!  *-*-*-*-gcc                64       CC64FLAGS                 =  -m64
+++  *-*-x86_64-*-gcc           _        CC64FLAGS                 =  -m32
+!!  *-*-x86_64-*-gcc           64       CC64FLAGS                 =  -m64
 !!  *-*-x86_64-*-gcc           _        CC64FLAGS                 =  -m32 -march=pentium2 -mtune=opteron
 !!  *-*-x86_64-*-gcc           64       CC64FLAGS                 =  -m64 -mtune=opteron
 ++  *-*-*-*-clang              _        CC64FLAGS                 =  -m32


### PR DESCRIPTION
This should addresss GitHub issue 152.  It is tested, and works with g++ 4.8.2 (Ubuntu/Linaro 4.8.2-19ubuntu1) and clang++ 3.4 (3.4-1ubuntu3).  Clang support does require, however, a separate patch to the bde library itself (for bsls_platform.h).

This allows for native building on Ubuntu-like ARM systems.  (Tested with both an HP Chromebook 11", and a heavily modified Motorola Atrix/WebDock.)