### PR TITLE
Remove extraneous "shell"

### DIFF
--- a/doc/waf.rst
+++ b/doc/waf.rst
@@ -97,7 +97,7 @@ To build and run the test drivers, use:
 
 ::
 
-   shell waf build --test run
+   waf build --test run
 
 For additional examples, see `Quick Reference`_.
 


### PR DESCRIPTION
I don’t think this “shell” should be here. It confused me at first.