### PR TITLE
Fix usage in python3

### DIFF
--- a/lib/python/bdebuild/buildenv/compilerinfo.py
+++ b/lib/python/bdebuild/buildenv/compilerinfo.py
@@ -147,7 +147,7 @@ def get_compilerinfos(hostname, uplid, file_):
 
 def get_command_output(args):
     try:
-        output = subprocess.check_output(args, stderr=subprocess.STDOUT).translate(None, '\n')
+        output = subprocess.check_output(args, stderr=subprocess.STDOUT).decode('utf8').replace('\n', '')
         return output
     except Exception as e:
         pass


### PR DESCRIPTION
Currently bde_build_env.py assume that the result of the subprocess.call is a string, this fails in python3 and even when we have the coorect toolset locally, and we are greeted by `No valid compilers on this machine.` This patch fixes that and I correctly have my compilers listed:

```
/data/Projects/diagram-server/clang_parser on  tcanabrava/fix_cmake_libraries! ⌚ 17:18:45
$ python --version
Python 3.8.6

/data/Projects/diagram-server/clang_parser on  tcanabrava/fix_cmake_libraries! ⌚ 17:21:45
$ bde_build_env.py --build-type=Release 
Using compiler: gcc-10.2.0
Using ufid: opt_exc_mt_64_cpp03
export BDE_CMAKE_UPLID=unix-linux-x86_64-5.4.72-gcc-10.2.0
export BDE_CMAKE_UFID=opt_exc_mt_64_cpp03
export BDE_CMAKE_BUILD_DIR="_build/unix-linux-x86_64-5.4.72-gcc-10.2.0-opt_exc_mt_64_cpp03"
export CXX=/usr/bin/g++
export CC=/usr/bin/gcc
export BDE_CMAKE_TOOLCHAIN=toolchains/linux/gcc-default
Using install directory: /data/Projects/diagram-server/clang_parser/_install
export BDE_CMAKE_INSTALL_DIR="/data/Projects/diagram-server/clang_parser/_install"
```