### PR TITLE
ignore ascii decode error

### DIFF
--- a/bin/cmake_build.py
+++ b/bin/cmake_build.py
@@ -24,7 +24,7 @@ if "Windows" == platform.system():
 def find_installdir(version):
     vswhere_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'vswhere.exe')
     output = subprocess.check_output([vswhere_path, '-legacy', '-format', 'json'])
-    compilers = json.loads(output.decode('ascii'))
+    compilers = json.loads(output.decode('ascii', errors='ignore'))
     for cl in compilers:
         if cl['installationVersion'].startswith(str(version)):
             return cl['installationPath']
@@ -56,7 +56,7 @@ def get_msvc_env(version, bitness):
     (out, err) = process.communicate()
 
     if (sys.version_info > (3, 0)):
-        out = out.decode('ascii')
+        out = out.decode('ascii', errors='ignore')
 
     for line in out.split("\n"):
         if '=' not in line:

--- a/lib/python/bdebuild/buildenv/main.py
+++ b/lib/python/bdebuild/buildenv/main.py
@@ -111,7 +111,7 @@ def unset_command():
 def find_installdir(version):
     vswhere_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', '..', 'bin', 'vswhere.exe')
     output = subprocess.check_output([vswhere_path, '-legacy', '-format', 'json'])
-    compilers = json.loads(output.decode('ascii'))
+    compilers = json.loads(output.decode('ascii', errors='ignore'))
     for cl in compilers:
         if cl['installationVersion'].startswith(version):
             return cl['installationPath']


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

no bug report yet

**Describe your changes**

add `errors=ignore` to all string decode call sites.

**Testing performed**

build on windows in mingw64

**Additional context**

my installation of vs has non ascii output in `vswhere.exe` which breaks the build script. this PR should've fixed it.

