### PR TITLE
fix a bug in cmake/layers/gtest.cmake.

### DIFF
--- a/cmake/layers/gtest.cmake
+++ b/cmake/layers/gtest.cmake
@@ -2,7 +2,7 @@
 
 bde_prefixed_override(gtest component_find_tests)
 function(gtest_component_find_tests component rootDir)
-    component_find_test_base(gtest_component_find_test ${ARGV})
+    component_find_tests_base(gtest_component_find_tests ${ARGV})
 
     bde_struct_get_field(componentName ${component} NAME)
     bde_utils_find_file_extension(test "${rootDir}/${componentName}" ".g.cpp")


### PR DESCRIPTION
Signed-off-by: Xudong Xiao <xdxiao@gmail.com>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Replace  component_find_test_base with component_find_**tests**_base

**Testing performed**
By adding "include(layers/gtest) into the "bde" repo's project.cmake, the old gtest.cmake would generate error. The fixed version makes no error.

**Additional context**
Add any other context about your contribution here.
