### PR TITLE
Run Python executable from CMake package

### DIFF
--- a/cmake/bde_runtest.cmake
+++ b/cmake/bde_runtest.cmake
@@ -3,9 +3,11 @@ if(BDE_RUNTEST_INCLUDED)
 endif()
 set(BDE_RUNTEST_INCLUDED true)
 
+find_package(Python)
+
 function(internal_setup_bde_test_runner)
     get_filename_component(dir ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
-    set_property(GLOBAL PROPERTY BDE_RUNTEST_COMMAND python ${dir}/bin/bde_runtest.py)
+    set_property(GLOBAL PROPERTY BDE_RUNTEST_COMMAND ${Python_EXECUTABLE} ${dir}/bin/bde_runtest.py)
 endfunction()
 internal_setup_bde_test_runner() # Call immediately for correctness of ${CMAKE_CURRENT_LIST_DIR}
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #38*

**Describe your changes**
Update the CMake test runner to locate the Python executable using the CMake Python package. This replaces the hard-coded 'python' searched in $PATH which would not locate a Python 3 interpreter installed as python3.

**Testing performed**
Have successfully run the test suite with this patch installed.