### PR TITLE
Use a canonical Python3 version

### DIFF
--- a/bin/bbs_build.py
+++ b/bin/bbs_build.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 from pylibinit import addlibpath
 addlibpath.add_lib_path()

--- a/bin/bbs_build_env.py
+++ b/bin/bbs_build_env.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 from pylibinit import addlibpath
 

--- a/bin/bbs_make_vscode.py
+++ b/bin/bbs_make_vscode.py
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 import os
 import subprocess
 import sys
-
 
 def quotedCMakeArgValue(value):
     if value in ["0", "OFF", "NO", "FALSE", "N"]:

--- a/bin/bde_build_env.py
+++ b/bin/bde_build_env.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 from pylibinit import addlibpath
 

--- a/bin/bde_make_vscode.py
+++ b/bin/bde_make_vscode.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 import os
 import subprocess

--- a/bin/bde_runtest.py
+++ b/bin/bde_runtest.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
+
+from checkversion import checkversion
+checkversion()
 
 from pylibinit import addlibpath
 

--- a/bin/checkversion.py
+++ b/bin/checkversion.py
@@ -1,0 +1,5 @@
+import sys
+
+def checkversion():
+    if sys.version_info[0] == 3 and sys.version_info[1] < 8:
+        raise Exception("Must be using at least Python 3.8")

--- a/bin/cmake_build.py
+++ b/bin/cmake_build.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 
+from checkversion import checkversion
+checkversion()
 
 import argparse
 import collections


### PR DESCRIPTION
The current check differs from file to file, some require python, some require python3.8.
 The current version of python is 3.10, and it's backward compatible, 
so we only need to test if a python version is *below* python3.8 before bailing out.

This future proofs the code and allows linux distros and windows installations to use newer python versions.