### PR TITLE
Python: Raw strings fix errors from invalid escape sequences

### DIFF
--- a/bin/bde-format-code-comment.py
+++ b/bin/bde-format-code-comment.py
@@ -88,7 +88,7 @@ def main():
 
     # Check if we're outside a balanced '//..' set
 
-    if len(re.findall("(//\.\.)", text[: code_block_span[0]])) % 2 == 1:
+    if len(re.findall(r"(//\.\.)", text[: code_block_span[0]])) % 2 == 1:
         print(doBdeFormat(args, text))
         sys.exit(0)
 
@@ -140,7 +140,7 @@ def main():
 
         l = re.sub(f"{linesep}[ ]{{{code_offset + 2}}}", linesep, l)
         l = l.replace(linesep, linesep + " " * code_offset + "//")
-        match = re.search("offset='(\d+)'", l)
+        match = re.search(r"offset='(\d+)'", l)
         if match:
             offset = int(match.group(1))
             if offset < min_offset or offset >= max_offset:

--- a/lib/python/bbs/common/sysutil.py
+++ b/lib/python/bbs/common/sysutil.py
@@ -81,7 +81,7 @@ def unversioned_platform():
     if s == "win32" or s == "os2":
         return s
 
-    return re.split("\d+$", s)[0]
+    return re.split(r"\d+$", s)[0]
 
 
 def is_mingw_environment():

--- a/lib/python/bbs/env/profile_utils.py
+++ b/lib/python/bbs/env/profile_utils.py
@@ -331,7 +331,7 @@ def get_compiler_version(compiler_type, cxx_path):
 
     if "clang" == compiler_type:
         version = get_command_output([cxx_path, "--version"])
-        m = re.search("version\s+([0-9\.]+)", version)
+        m = re.search(r"version\s+([0-9\.]+)", version)
         version = m.group(1) if m else "0.0.0"
 
     return version

--- a/lib/python/bdebuild/buildenv/compilerinfo.py
+++ b/lib/python/bdebuild/buildenv/compilerinfo.py
@@ -174,7 +174,7 @@ def get_compiler_version(compiler_type, cxx_path):
 
     if "clang" == compiler_type:
         version = get_command_output([cxx_path, "--version"])
-        m = re.search("version\s+([0-9\.]+)", version)
+        m = re.search(r"version\s+([0-9\.]+)", version)
         version = m.group(1) if m else "0.0.0"
 
     return version

--- a/lib/python/bdebuild/common/sysutil.py
+++ b/lib/python/bdebuild/common/sysutil.py
@@ -81,7 +81,7 @@ def unversioned_platform():
     if s == "win32" or s == "os2":
         return s
 
-    return re.split("\d+$", s)[0]
+    return re.split(r"\d+$", s)[0]
 
 
 def is_mingw_environment():


### PR DESCRIPTION
Fixes these Python 3 errors:

    $ bde-tools/bin/bbs_build_env list
    /root/bde-tools/lib/python/bbs/common/sysutil.py:84: SyntaxWarning: invalid escape sequence '\d'
      return re.split("\d+$", s)[0]
    /root/bde-tools/lib/python/bbs/env/profile_utils.py:334: SyntaxWarning: invalid escape sequence '\s'
      m = re.search("version\s+([0-9\.]+)", version)

Then, grepped `git grep '[^r]".*\\[ds.].*"' | grep py:` and fixed those strings, too.